### PR TITLE
Remove use of wget for registration

### DIFF
--- a/bootstrap/centos/register.sh
+++ b/bootstrap/centos/register.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -ex
 # Assumes load balancer is passed as an environment variable
 exec > >(tee /var/log/codeontap/register.log|logger -t codeontap-register -s 2>/dev/console) 2>&1
-INSTANCE=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
-aws elb register-instances-with-load-balancer --load-balancer-name $LOAD_BALANCER --instances $INSTANCE
+INSTANCE=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+AVAILABILITY_ZONE="$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)"
+REGION=${AVAILABILITY_ZONE::-1}
+aws --region "${REGION}" elb register-instances-with-load-balancer --load-balancer-name $LOAD_BALANCER --instances $INSTANCE
 #
 
 


### PR DESCRIPTION
Some AWS images (ECS) don't have wget installed by default. They all have curl so lets use that instead.