### PR TITLE
Add users for docker in docker scenarios

### DIFF
--- a/bootstrap/centos/ecs.sh
+++ b/bootstrap/centos/ecs.sh
@@ -42,6 +42,16 @@ if [[ (-n "${ECS_LOG_DRIVER}") && ("${ECS_LOG_DRIVER}" != "awslogs") ]]; then
 	fi
 fi
 
+# Add additonal users to docker group
+if [[ -n "${DOCKER_USERS}" ]]; then 
+    IFS=',' read -ra DOCKER_USERS_LIST <<< "${DOCKER_USERS}"
+    for DOCKER_USER in "${DOCKER_USERS_LIST[@]}" ; do
+        IFS=":" read -ra DOCKER_USER_DETAIL <<< "${DOCKER_USER}"
+        useradd -u "${DOCKER_USER_DETAIL[1]}" -M -s /sbin/nologin "${DOCKER_USER_DETAIL[0]}"
+        usermod -a -G docker "${DOCKER_USER_DETAIL[0]}"
+    done
+fi 
+
 # Restart docker to ensure it picks up any EBS volume mounts and updated configuration settings
 # - see https://github.com/aws/amazon-ecs-agent/issues/62
 /sbin/service docker restart 

--- a/bootstrap/centos/ecs.sh
+++ b/bootstrap/centos/ecs.sh
@@ -47,8 +47,7 @@ if [[ -n "${DOCKER_USERS}" ]]; then
     IFS=',' read -ra DOCKER_USERS_LIST <<< "${DOCKER_USERS}"
     for DOCKER_USER in "${DOCKER_USERS_LIST[@]}" ; do
         IFS=":" read -ra DOCKER_USER_DETAIL <<< "${DOCKER_USER}"
-        useradd -u "${DOCKER_USER_DETAIL[1]}" -M -s /sbin/nologin "${DOCKER_USER_DETAIL[0]}"
-        usermod -a -G docker "${DOCKER_USER_DETAIL[0]}"
+        /usr/sbin/adduser -u "${DOCKER_USER_DETAIL[1]}" -M -N -s /sbin/nologin -G docker "${DOCKER_USER_DETAIL[0]}"
     done
 fi 
 


### PR DESCRIPTION
In scenarios where you want to run docker from within a docker container the recommend approach is to use the docker service of the host the container lives on. 

To do this you need to give the user the container is  running under have access to the Docker service on the host. To do this we need to have a matching user with the same UID  on the docker host that is a member of the docker group on the host. 

This PR allows for an environment variable DOCKER_USERS to be set which accepts a list of comma separated users in the format of <username>:<uid> 

So to create bob and fred you would set DOCKER_USERS=bob:1234,fred:5678 


