### PR TITLE
Add specific volume for dockerVolumes

### DIFF
--- a/bootstrap/centos/init.sh
+++ b/bootstrap/centos/init.sh
@@ -31,7 +31,7 @@ function mountDevice()
     file_system=$3
     
     if [[ ! -d $mount_point ]]; then
-            mkdir $mount_point
+            mkdir -p $mount_point
     fi
 
     echo "------${device_name}---$(date)------"

--- a/bootstrap/centos/init.sh
+++ b/bootstrap/centos/init.sh
@@ -191,7 +191,4 @@ mountDevice /dev/xvdp /codeontap ext4
 ln -s /codeontap /product
 mountDevice /dev/xvdc /cache
 mountDevice /dev/xvdt /temp
-
-
-
-
+mountDevice /dev/xvdv /var/lib/docker/volumes


### PR DESCRIPTION
Adds the ability to specify the /dev/xvdv as a dedicated volume for docker volume storage. By default it is hosted on the root disk partition