### PR TITLE
<fix> ecs volume mounts for docker

### DIFF
--- a/bootstrap/centos/ecs.sh
+++ b/bootstrap/centos/ecs.sh
@@ -58,5 +58,7 @@ fi
 
 # Restart docker to ensure it picks up any EBS volume mounts and updated configuration settings
 # - see https://github.com/aws/amazon-ecs-agent/issues/62
-/sbin/service docker restart 
+/sbin/service docker stop
+mount -a
+/sbin/service docker start
 /sbin/start ecs


### PR DESCRIPTION
Mounts all volumes while docker is stopped. This gets around a weird bug where a mount for /var/lib/docker/volumes seems to be unmounted while the docker services is being setup 

