### PR TITLE
feat(efs): accesspoint and iam support in bootstrap

### DIFF
--- a/bootstrap/centos/efs.sh
+++ b/bootstrap/centos/efs.sh
@@ -1,24 +1,44 @@
 #!/bin/bash
-# Assumes EFS_FILE_SYSTEM_ID - Environment Variable - The ID of the EFS File System 
-# Assumes EFS_MOUNT_PATH - Environment Variable - The Path on the EFS File System
-# Assumes EFS_OS_MOUNT_PATH - Environment Variable - Location on the OS where the share should mount 
-# Assumes amazon-efs-utils has been installed already 
+# EFS_FILE_SYSTEM_ID - Environment Variable - The ID of the EFS File System
+# EFS_MOUNT_PATH - Environment Variable - The Path on the EFS File System
+# EFS_OS_MOUNT_PATH - Environment Variable - Location on the OS where the share should mount
+# EFS_CREATE_MOUNT - Environment Variable - Create the mount on the EFS Share
+# EFS_IAM_ENABLED - Environment Variable - To use IAM or not
+# EFS_ACCESS_POINT_ID - Environment Variable - Use an EFS Access point for the mount location
+# Assumes amazon-efs-utils has been installed already
 
-# Mount EFS to a temp directory and create the EFS path if it doesn't exist  
+EFS_IAM_ENABLED="${EFS_IAM_ENABLED:-false}"
+EFS_CREATE_MOUNT="${EFS_CREATE_MOUNT:-true}"
+
+# Mount EFS to a temp directory and create the EFS path if it doesn't exist
 # Thie ensures the permanent mount works as expected
-temp_dir="$(mktemp -d -t efs.XXXXXXXX)"
-mount -t efs "${EFS_FILE_SYSTEM_ID}:/" ${temp_dir} || exit $?
-if [[ ! -d "${temp_dir}/${EFS_MOUNT_PATH}" ]]; then 
-    mkdir -p "${temp_dir}/${EFS_MOUNT_PATH}"
+if [[ "${EFS_CREATE_MOUNT}" == "true" ]]; then
+    temp_dir="$(mktemp -d -t efs.XXXXXXXX)"
+    mount -t efs "${EFS_FILE_SYSTEM_ID}:/" ${temp_dir} || exit $?
+    if [[ ! -d "${temp_dir}/${EFS_MOUNT_PATH}" ]]; then
+        mkdir -p "${temp_dir}/${EFS_MOUNT_PATH}"
 
-    # Allow Full Access to volume (Allows for unkown container access )
-    chmod -R ugo+rwx "${temp_dir}/${EFS_MOUNT_PATH}"
+        # Allow Full Access to volume (Allows for unkown container access )
+        chmod -R ugo+rwx "${temp_dir}/${EFS_MOUNT_PATH}"
+    fi
+    umount ${temp_dir}
 fi
-umount ${temp_dir}
+
+# Build mount options
+EFS_OPTIONS=( "_netdev" "tls" )
+if [[ "${EFS_IAM_ENABLED}" == "true" ]]; then
+    EFS_OPTIONS+=('iam')
+fi
+
+if [[ -n "${EFS_ACCESS_POINT_ID}" ]]; then
+    EFS_OPTIONS+=("accesspoint=${EFS_ACCESS_POINT_ID}")
+fi
+
+EFS_OPTIONS="$(IFS=,; echo "${EFS_OPTIONS[*]}")"
 
 # Create and Mount volume
 mkdir -p ${EFS_OS_MOUNT_PATH}
-mount -t efs "${EFS_FILE_SYSTEM_ID}:${EFS_MOUNT_PATH}" "${EFS_OS_MOUNT_PATH}" || exit $?
+mount -t efs -o "${EFS_OPTIONS}" "${EFS_FILE_SYSTEM_ID}:${EFS_MOUNT_PATH}" "${EFS_OS_MOUNT_PATH}" || exit $?
 
 # Add to permanent mount in case of reboots
-echo -e "${EFS_FILE_SYSTEM_ID}:${EFS_MOUNT_PATH} ${EFS_OS_MOUNT_PATH} efs defaults,_netdev 0 0" >> /etc/fstab
+echo -e "${EFS_FILE_SYSTEM_ID}:${EFS_MOUNT_PATH} ${EFS_OS_MOUNT_PATH} efs ${EFS_OPTIONS} 0 0" >> /etc/fstab


### PR DESCRIPTION
## Description
Adds support for IAM and access points in EFS mounts

## Motivation and Context
Required to support updates to the EFS component which now supports IAM authentication and access point based mounts 

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- cloudinit-aws - https://github.com/hamlet-io/cloudinit-aws/pull/27
- engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/117
- engine - https://github.com/hamlet-io/engine/pull/1377

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
